### PR TITLE
Agent discovery: Link headers, well-known endpoints, markdown negotiation, Content-Signal

### DIFF
--- a/src/app/agents/home.md.ts
+++ b/src/app/agents/home.md.ts
@@ -1,0 +1,72 @@
+// Markdown representation of the RedwoodSDK homepage, served to agents
+// that request `Accept: text/markdown` (see `markdownForAgents` middleware).
+//
+// Keep this file human-authored and semantically aligned with the HTML home
+// page so agents get a clean, prose-first summary without stripping decoration
+// from the React tree.
+
+export const homeMarkdown = `# RedwoodSDK
+
+> A simple framework for humans.
+>
+> Server-first React, running on the Cloudflare platform.
+> Simple to build. Easy to maintain.
+
+## Get started
+
+Scaffold a Vite project powered by RedwoodSDK. Includes RSC, type-safe routing/SQL, and Cloudflare integration.
+
+\`\`\`sh
+npx create-rwsdk my-project-name
+\`\`\`
+
+## Principles
+
+Simplicity for humans is clarity for AI. By using React, TypeScript, and Cloudflare without custom "noise," AI focuses on your business logic instead of navigating framework rules.
+
+| Principle        | Technical Reality                               | AI Advantage                                            |
+| ---------------- | ----------------------------------------------- | ------------------------------------------------------- |
+| Without Magic    | No code-gen or implied routing                  | **Clarity:** AI reads exactly what executes              |
+| Composability    | Standard functions and types                    | **Logic:** AI follows your code, not a policy            |
+| Web Standards    | If the browser or platform has it, we use it    | **Context:** AI uses core web knowledge                  |
+| Server-First     | Linear data flow                                | **Signal:** Higher accuracy for auditing/writing         |
+
+## Routing
+
+Composable functions that describe your app using standard TypeScript.
+
+## Async React
+
+A unified mental model for bridging the gap between the client and server.
+
+- **Async Engine** — server components can \`await\` anywhere.
+- **Streaming Bridge** — stream server output into the client progressively.
+- **Action Loop** — server actions compose with async React out of the box.
+
+## Realtime
+
+\`useSyncedState\` is a drop-in replacement for \`useState\` that synchronizes state across all connected clients in real-time.
+
+\`\`\`tsx
+// Before
+const [count, setCount] = useState(0);
+
+// After
+const [count, setCount] = useSyncedState(0, 'global-count');
+\`\`\`
+
+Transform any local state into a globally synchronized, bi-directional data stream. When you call \`useSyncedState\`, it persists the state on your server automatically. Your server can push data down to the clients, or clients can push data up to the server — without writing a single WebSocket handler.
+
+Learn more: https://rwsdk.com/realtime
+
+## Links for agents
+
+- Documentation: https://docs.rwsdk.com
+- API catalog: https://rwsdk.com/.well-known/api-catalog
+- Agent skills: https://rwsdk.com/.well-known/agent-skills/index.json
+- Sitemap: https://rwsdk.com/sitemap.xml
+- Blog: https://rwsdk.com/blog
+- Talks: https://rwsdk.com/talks
+- Contributors: https://rwsdk.com/contributors
+- GitHub: https://github.com/redwoodjs/sdk
+`;

--- a/src/app/agents/middleware.ts
+++ b/src/app/agents/middleware.ts
@@ -1,0 +1,77 @@
+import { RouteMiddleware } from "rwsdk/router";
+import { homeMarkdown } from "./home.md";
+
+/**
+ * Per-path markdown bodies returned when an agent sends `Accept: text/markdown`.
+ * Keep the keys aligned with the router so additions stay discoverable.
+ */
+const MARKDOWN_RESPONSES: Record<string, string> = {
+  "/": homeMarkdown,
+};
+
+/**
+ * Agent-facing Link header emitted on the homepage (RFC 8288).
+ * Surfaces the well-known agent-discovery endpoints without requiring the
+ * agent to guess paths or parse HTML.
+ */
+const HOME_LINK_HEADER = [
+  `</.well-known/api-catalog>; rel="api-catalog"`,
+  `<https://docs.rwsdk.com>; rel="service-doc"; type="text/html"`,
+  `</.well-known/agent-skills/index.json>; rel="https://agentskills.io/rel/index"; type="application/json"`,
+  `</sitemap.xml>; rel="sitemap"; type="application/xml"`,
+].join(", ");
+
+/**
+ * Content-negotiate HTML vs Markdown for agent clients.
+ *
+ * When the request's `Accept` header includes `text/markdown`, return a
+ * hand-authored markdown body for the path (if we have one) and short-circuit
+ * routing. Browsers don't send `text/markdown`, so they keep getting HTML.
+ *
+ * Responses set `Vary: Accept` so intermediaries cache HTML and markdown
+ * separately, and `x-markdown-tokens` as a coarse-grained token hint for
+ * agents sizing context windows.
+ *
+ * See https://developers.cloudflare.com/fundamentals/reference/markdown-for-agents/
+ */
+export const markdownForAgents = (): RouteMiddleware => ({ request }) => {
+  const accept = request.headers.get("Accept") ?? "";
+  if (!accept.toLowerCase().includes("text/markdown")) return;
+
+  const url = new URL(request.url);
+  const body = MARKDOWN_RESPONSES[url.pathname];
+  if (!body) return;
+
+  // Rough token estimate: ~4 chars per token. Good enough as a hint for agents
+  // that want to size context before fetching.
+  const tokenEstimate = Math.ceil(body.length / 4);
+
+  return new Response(body, {
+    status: 200,
+    headers: {
+      "Content-Type": "text/markdown; charset=utf-8",
+      "Vary": "Accept",
+      "x-markdown-tokens": String(tokenEstimate),
+      "Cache-Control": "public, max-age=300",
+    },
+  });
+};
+
+/**
+ * Attach `Link` and `Vary` headers on the homepage so agents can discover
+ * supporting resources (api-catalog, docs, sitemap, skills index) without
+ * parsing HTML, and so caches key HTML vs markdown responses separately.
+ */
+export const setAgentDiscoveryHeaders = (): RouteMiddleware => ({ request, response }) => {
+  const url = new URL(request.url);
+  if (url.pathname !== "/") return;
+
+  response.headers.set("Link", HOME_LINK_HEADER);
+
+  // We content-negotiate on Accept for `/` (markdown vs HTML), so advertise it.
+  const existingVary = response.headers.get("Vary");
+  response.headers.set(
+    "Vary",
+    existingVary ? `${existingVary}, Accept` : "Accept",
+  );
+};

--- a/src/app/agents/wellKnown.ts
+++ b/src/app/agents/wellKnown.ts
@@ -1,0 +1,77 @@
+/**
+ * Handlers for the various `/.well-known/*` endpoints that advertise
+ * agent-discovery metadata. Each handler returns a plain `Response` so the
+ * router can mount them directly.
+ */
+
+const ORIGIN = "https://rwsdk.com";
+const DOCS = "https://docs.rwsdk.com";
+
+/**
+ * RFC 9727 API Catalog — application/linkset+json.
+ *
+ * RedwoodSDK is a framework, not a hosted API, so the catalog currently
+ * surfaces the documentation site as the primary service. If/when rwsdk.com
+ * grows hosted APIs (e.g. the realtime endpoint) add new linkset entries with
+ * `service-desc` (OpenAPI) alongside `service-doc` and `status`.
+ */
+export const apiCatalog = async () => {
+  const body = {
+    linkset: [
+      {
+        anchor: `${ORIGIN}/`,
+        "service-doc": [
+          {
+            href: `${DOCS}/`,
+            type: "text/html",
+            hreflang: ["en"],
+            title: "RedwoodSDK documentation",
+          },
+        ],
+        status: [
+          {
+            href: `${ORIGIN}/`,
+            type: "text/html",
+          },
+        ],
+      },
+    ],
+  };
+
+  return new Response(JSON.stringify(body, null, 2), {
+    status: 200,
+    headers: {
+      "Content-Type": "application/linkset+json",
+      "Cache-Control": "public, max-age=3600",
+    },
+  });
+};
+
+/**
+ * Agent Skills Discovery index (https://agentskills.io, v0.2.0).
+ *
+ * We don't ship any skills yet — publishing the empty index still satisfies
+ * discovery, and consumers can watch this URL rather than guessing whether
+ * skills exist. Populate `skills[]` as we author them.
+ */
+export const agentSkillsIndex = async () => {
+  const body = {
+    $schema: "https://agentskills.io/schema/v0.2.0.json",
+    version: "0.2.0",
+    skills: [] as Array<{
+      name: string;
+      type: string;
+      description: string;
+      url: string;
+      sha256: string;
+    }>,
+  };
+
+  return new Response(JSON.stringify(body, null, 2), {
+    status: 200,
+    headers: {
+      "Content-Type": "application/json",
+      "Cache-Control": "public, max-age=3600",
+    },
+  });
+};

--- a/src/worker.tsx
+++ b/src/worker.tsx
@@ -3,6 +3,11 @@ import { render, route, prefix, layout } from "rwsdk/router";
 import { Document } from "src/document";
 import Home from "src/pages/home/page";
 import { setCommonHeaders } from "src/headers";
+import {
+  markdownForAgents,
+  setAgentDiscoveryHeaders,
+} from "src/agents/middleware";
+import { apiCatalog, agentSkillsIndex } from "src/agents/wellKnown";
 import sitemap from "./sitemap";
 import PersonalSoftware from "src/pages/readme/personal-software/page";
 import { notFound } from "src/utils/notFound";
@@ -330,6 +335,10 @@ export default defineApp([
     ctx.theme = (match?.[1] as "dark" | "light" | "system") || "system";
   },
   setCommonHeaders(),
+  setAgentDiscoveryHeaders(),
+  // Short-circuits HTML rendering for agent clients that send
+  // `Accept: text/markdown`. Must run before `render(Document, ...)`.
+  markdownForAgents(),
 
   ...syncedStateRoutes((env: any) => env.SYNCED_STATE),
 
@@ -372,10 +381,22 @@ export default defineApp([
       });
     }),
     route("/robots.txt", async () => {
-      const robotsTxt = `User-agent: *
-        Allow: /
-        Disallow: /start
-        Sitemap: https://rwsdk.com/sitemap.xml`;
+      // Content-Signal directives declare our AI-usage preferences per the
+      // contentsignals.org / draft-romm-aipref-contentsignals spec:
+      //   search=yes   — indexing for traditional search is welcome
+      //   ai-train=no  — don't use our content to train models
+      //   ai-input=yes — agents can read pages at request time (RAG etc.)
+      const robotsTxt = [
+        "# AI content-usage preferences (contentsignals.org)",
+        "Content-Signal: search=yes, ai-train=no, ai-input=yes",
+        "",
+        "User-agent: *",
+        "Content-Signal: search=yes, ai-train=no, ai-input=yes",
+        "Allow: /",
+        "Disallow: /start",
+        "",
+        "Sitemap: https://rwsdk.com/sitemap.xml",
+      ].join("\n");
 
       return new Response(robotsTxt, {
         status: 200,
@@ -384,6 +405,9 @@ export default defineApp([
         },
       });
     }),
+
+    route("/.well-known/api-catalog", apiCatalog),
+    route("/.well-known/agent-skills/index.json", agentSkillsIndex),
 
     prefix("/changelog", changelogRoutes),
 


### PR DESCRIPTION
Implements the feasible subset of the [isitagentready.com](https://isitagentready.com) checks for a marketing/framework site.

## What's in

### Discovery headers
- **`Link` response header on `/`** (RFC 8288) advertising:
  - `rel="api-catalog"` → `/.well-known/api-catalog`
  - `rel="service-doc"` → `https://docs.rwsdk.com`
  - `rel="https://agentskills.io/rel/index"` → `/.well-known/agent-skills/index.json`
  - `rel="sitemap"` → `/sitemap.xml`
- Merges `Vary: Accept` on `/` so caches key HTML vs markdown separately.

### Markdown for agents
- New middleware: when the `Accept` header includes `text/markdown`, `/` returns a hand-authored markdown summary with `Content-Type: text/markdown; charset=utf-8`, `Vary: Accept`, and an `x-markdown-tokens` hint for agent context sizing. Browsers keep getting HTML (they don't send `text/markdown`).
- The markdown body lives in `src/app/agents/home.md.ts` — hand-authored rather than HTML-converted, because the React page is heavy on decoration. Keep it in sync with the page when the messaging changes.

### Well-known endpoints
- **`/.well-known/api-catalog`** — RFC 9727 `application/linkset+json` with a linkset entry for `rwsdk.com/` pointing to docs (`service-doc`) and a `status` anchor.
- **`/.well-known/agent-skills/index.json`** — Agent Skills Discovery v0.2.0 index with `$schema`, `version`, and an empty `skills` array (populate as we author skills).

### robots.txt
- Added `Content-Signal: search=yes, ai-train=no, ai-input=yes` per [contentsignals.org](https://contentsignals.org) — both at the top level and inside the `User-agent: *` block.
- Fixed a pre-existing bug: the old robots.txt used a template literal with leading whitespace on every directive, which some parsers reject.

## What's deferred (and why)

- **OAuth/OIDC discovery, OAuth Protected Resource Metadata, MCP Server Card** — rwsdk.com doesn't expose protected APIs or an MCP server. Publishing empty/placeholder metadata here would be dishonest signaling. Add when there's a real resource to describe.
- **WebMCP** (`navigator.modelContext.provideContext()`) — worth doing once we pick concrete agent-callable actions (e.g. "scaffold a project", "search docs"). Belongs in `src/client.tsx`.
- **x402 / UCP / ACP** — commerce/payment protocols; the marketing site has nothing to sell to agents.

## Files

- `src/app/agents/home.md.ts` (new) — markdown body for `/`
- `src/app/agents/middleware.ts` (new) — `markdownForAgents()`, `setAgentDiscoveryHeaders()`
- `src/app/agents/wellKnown.ts` (new) — `apiCatalog`, `agentSkillsIndex`
- `src/worker.tsx` — wire the new middlewares into `defineApp`, register the two well-known routes, rewrite robots.txt

## Manual verification

```sh
curl -sI https://rwsdk.com/ | grep -i '^link:'
curl -s -H 'Accept: text/markdown' https://rwsdk.com/ | head
curl -s https://rwsdk.com/.well-known/api-catalog
curl -s https://rwsdk.com/.well-known/agent-skills/index.json
curl -s https://rwsdk.com/robots.txt
```
